### PR TITLE
Exit packaging script on failure.

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 rm -rf node_modules
 if [ -z "${ADDON_ARCH}" ]; then


### PR DESCRIPTION
Found while attempting a Node 12 build (which failed).